### PR TITLE
Preparations to use gov.uk style frontend

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,11 @@ gem 'jbuilder', '~> 2.5'
 # Use ActiveModel has_secure_password
 # gem 'bcrypt', '~> 3.1.7'
 
+# gov.uk frontend gems
+gem 'govuk_template'
+gem 'govuk_frontend_toolkit'
+gem 'govuk_elements_rails'
+
 # Use Capistrano for deployment
 # gem 'capistrano-rails', group: :development
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -60,6 +60,15 @@ GEM
     govuk-lint (1.2.1)
       rubocop (~> 0.39.0)
       scss_lint
+    govuk_elements_rails (2.2.0)
+      govuk_frontend_toolkit (>= 5.0.0)
+      rails (>= 4.1.0)
+      sass (>= 3.2.0)
+    govuk_frontend_toolkit (5.0.1)
+      rails (>= 3.1.0)
+      sass (>= 3.2.0)
+    govuk_template (0.19.1)
+      rails (>= 3.1)
     i18n (0.7.0)
     jbuilder (2.6.0)
       activesupport (>= 3.0.0, < 5.1)
@@ -194,6 +203,9 @@ DEPENDENCIES
   byebug
   coffee-rails (~> 4.2)
   govuk-lint
+  govuk_elements_rails
+  govuk_frontend_toolkit
+  govuk_template
   jbuilder (~> 2.5)
   jquery-rails
   listen (~> 3.0.5)
@@ -208,9 +220,6 @@ DEPENDENCIES
   tzinfo-data
   uglifier (>= 1.3.0)
   web-console
-
-RUBY VERSION
-   ruby 2.3.1p112
 
 BUNDLED WITH
    1.13.1

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -13,3 +13,5 @@
  *= require_tree .
  *= require_self
  */
+
+@import "govuk-elements";

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -15,3 +15,4 @@
  */
 
 @import "govuk-elements";
+@import "base";

--- a/app/assets/stylesheets/base.scss
+++ b/app/assets/stylesheets/base.scss
@@ -1,0 +1,55 @@
+/* sensible default styles for main elements */
+
+main {
+
+  h1 {
+    @extend .heading-xlarge !optional;
+  }
+
+  h2 {
+    @extend .heading-large !optional;
+  }
+
+  h3 {
+    @extend .heading-medium !optional;
+  }
+
+  h4 {
+    @extend .heading-small !optional;
+  }
+
+  ul,
+  ol {
+    @extend .list !optional;
+  }
+
+  ul {
+    @extend .list-bullet !optional;
+  }
+
+  ol {
+    @extend .list-number !optional;
+  }
+
+  strong {
+    @extend .bold !optional;
+  }
+
+  /* forms */
+
+  input,
+  select,
+  textarea {
+    @extend .form-control !optional;
+  }
+
+  label {
+    @extend .form-label !optional;
+  }
+
+  input[type=submit],
+  button {
+    @extend .button !optional;
+  }
+
+} /* /main */

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,14 +1,17 @@
-<!DOCTYPE html>
-<html>
-  <head>
-    <title>ComPrototype</title>
-    <%= csrf_meta_tags %>
+<% content_for :page_title do %>
+  ComPrototype
+<% end %>
 
-    <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload' %>
-    <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
-  </head>
+<% content_for :head do %>
+  <%= csrf_meta_tags %>
+  <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload' %>
+  <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
+<% end %>
 
-  <body>
-    <%= yield %>
-  </body>
-</html>
+<% content_for :content do %>
+  <main id="content" tabindex="-1">
+    <%= content_for?(:main) ? yield(:main) : yield %>
+  </main>
+<% end %>
+
+<%= render file: 'layouts/govuk_template' %>


### PR DESCRIPTION
This adds all the necessary frontend gems and prepares the CSS and layout to produce gov.uk styled pages.
After this has been merged, you can use simple HTML in views or more complex HTML copied and pasted from [Elements](http://govuk-elements.herokuapp.com/).

What still needs to be done:

* At some point we need to swap `govuk_template` for the `slimmer` gem. I tried to do that but was running into issues, so decided to go the simplest route first. Slimmer would be needed to a) automatically update all the assets and b) to get the gov.uk content in the header, footer, breadcrumbs, etc. and c) to use Gov.uk Components. All of that is not important in the beginning but will get more important when we plan to make this customer-facing.
* The general layout can be extended (e.g. with a title or a sidebar) but that should be done when and if it is needed. Look into [govuk_template](https://github.com/alphagov/govuk_template) to see all the possible hooks etc.

I tested everything in a test page which I removed again. It looked like this:
![com-prototype-frontend](https://cloud.githubusercontent.com/assets/108893/20606600/efda7502-b269-11e6-9a05-17a1bea815c1.png)
